### PR TITLE
Switch default windows entrypoint to `RemoteSigned` execution policy

### DIFF
--- a/aztra_win_wrapper.bat
+++ b/aztra_win_wrapper.bat
@@ -1,2 +1,2 @@
 @echo off
-powershell -ExecutionPolicy Bypass -NoExit -NoLogo -File "%~dp0aztra-up.ps1"
+powershell -ExecutionPolicy RemoteSigned -NoExit -NoLogo -File "%~dp0aztra-up.ps1"


### PR DESCRIPTION
Previously, the convenient Windows entrypoint made use of `-ExecutionPolicy Bypass`. This isn't exactly clean and wouldn't be considered reasonable/compliant behavior. It might even trigger detections on some endpoints. I think there was a reason for this setting though when I originally included it. I'll need to test this properly before merging, might have to with `Unrestricted` instead ...

Both of these options are still far from perfect though, maybe in the long run I should go with an even stricter policy and provide a code signing cert?